### PR TITLE
Update wallaby.js

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -25,6 +25,7 @@ module.exports = function (wallaby) {
 
 		testFramework: 'ava',
 		debug: true,
+		workers: {recycle: true},
 		setup: (w) => {
 			if (!global._callsiteReplaced) {
 				const Module = require('module').Module;

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,5 +1,5 @@
 module.exports = function (wallaby) {
-  // Need to set this variable to get
+	// Need to set this variable to get
 	process.env.DEBUG = '*,-ava,-babel';
 
 	return {
@@ -25,9 +25,27 @@ module.exports = function (wallaby) {
 
 		testFramework: 'ava',
 		debug: true,
-		workers: {
-			initial: 1,
-			regular: 1
+		setup: (w) => {
+			if (!global._callsiteReplaced) {
+				const Module = require('module').Module;
+				const modulePrototype = Module.prototype;
+				const originalRequire = modulePrototype.require;
+				modulePrototype.require = function (filePath) {
+					if (filePath === 'callsite') {
+						return () => {
+							const result = originalRequire.call(this, filePath)();
+							result.shift();
+							console.log(result.map(r => r.getFileName()));
+							const fileName = result[1].getFileName()
+								.replace(w.projectCacheDir, 'enchanted-debug');
+							result[1] = {getFileName: () => fileName};
+							return result;
+						};
+					}
+					return originalRequire.call(this, filePath);
+				};
+				global._callsiteReplaced = true;
+			}
 		}
 	};
 };


### PR DESCRIPTION
Fixed wallaby config as discussed at https://twitter.com/sindresvendby/status/815909523424772096.

The issue is not with parallelism/serial runs, but with the fact that tests assume that they are running from the local folder and it's not the case with wallaby.js (it runs tests [from its own local cache](https://wallabyjs.com/docs/intro/how-it-works.html#wallabyjs-cache)).

I have addressed the issue by using the [setup function](https://wallabyjs.com/docs/config/bootstrap.html) and monkey-patching the `callsite` module to return the expected local folder instead of the real instrumented cache folder.